### PR TITLE
trim api key before using it

### DIFF
--- a/src/Forge.php
+++ b/src/Forge.php
@@ -91,7 +91,7 @@ class Forge
      */
     public function setApiKey($apiKey, $guzzle = null)
     {
-        $this->apiKey = $apiKey;
+        $this->apiKey = trim($apiKey);
 
         $this->guzzle = $guzzle ?: new HttpClient([
             'base_uri' => 'https://forge.laravel.com/api/v1/',


### PR DESCRIPTION
If the api key is read from a file, it may have whitespace or line breaks at the end. The api key is therefore invalid.

This leads to strange errors since the Forge API will redirect the client to the HTML login page instead of returning a 401 Unauthorized error. The returned HTML form the web page is not expected and results in the following cryptic error:

> Fatal error: Uncaught TypeError: Cannot access offset of type string on string in /app/vendor/laravel/forge-sdk/src/Actions/ManagesServers.php:46

Trimming the key before using it in the client makes sure that this edge case is handled correctly.